### PR TITLE
feat(utils): add centralized roles and permissions utility

### DIFF
--- a/backend/src/services/adminService.js
+++ b/backend/src/services/adminService.js
@@ -1,6 +1,7 @@
 import companiesModel from "../models/companiesModel.js";
 import UserModel from "../models/userModel.js";
 import { request, response } from "express";
+import { Roles } from "../utils/roles.js"; 
 
 /**
  * Service class responsible for managing the logic of admin creation.
@@ -31,7 +32,7 @@ export default class AdminService {
         return;
       }
 
-      req.body.role_id = 2;
+      req.body.role_id = Roles.ADMIN;
 
       await UserModel.createUser(req.body);
 

--- a/backend/src/services/workerService.js
+++ b/backend/src/services/workerService.js
@@ -1,6 +1,7 @@
 import companiesModel from "../models/companiesModel.js";
 import UserModel from "../models/userModel.js";
 import { request, response } from "express";
+import { Roles } from "../utils/roles.js"; 
 
 /**
  * Service class responsible for handling user workers.
@@ -34,7 +35,7 @@ export default class WorkerServices {
       // Clone the request body and overwrite role_id
       const userData = {
         ...req.body,
-        role_id: 3, // worker role
+        role_id: Roles.STAFF, // worker role
       };
 
       console.log(userData)

--- a/backend/src/utils/roles.js
+++ b/backend/src/utils/roles.js
@@ -1,0 +1,77 @@
+// utils/roles.js
+
+/**
+ * Centralized definition of system Roles and Permissions.
+ *
+ * Use these constants instead of hardcoding numeric IDs or strings.
+ * This improves readability, avoids "magic numbers/strings", and makes
+ * the system easier to maintain.
+ */
+
+// --------------------
+// Roles
+// --------------------
+
+/**
+ * Roles available in the system.
+ *
+ * Each role is represented by a numeric ID that matches the value stored
+ * in the database (rol_id).
+ */
+export const Roles = Object.freeze({
+  SUPER_ADMIN: 1,
+  ADMIN: 2,
+  STAFF: 3,
+});
+
+// --------------------
+// Permissions
+// --------------------
+
+/**
+ * Permissions available in the system.
+ *
+ * Each permission is grouped by domain/module.
+ * These strings must match the "name" field in the database.
+ */
+export const Permissions = Object.freeze({
+  COMPANY: Object.freeze({
+    CREATE: "company_create",
+    READ: "company_read",
+    UPDATE: "company_update",
+    DELETE: "company_delete",
+  }),
+  USER: Object.freeze({
+    CREATE: "user_create",
+    CREATE_ADMIN: "user_create_admin",
+    CREATE_STAFF: "user_create_staff",
+    READ: "user_read",
+    UPDATE: "user_update",
+    DELETE: "user_delete",
+  }),
+  CUSTOMER: Object.freeze({
+    CREATE: "customer_create",
+    READ: "customer_read",
+    UPDATE: "customer_update",
+    DELETE: "customer_delete",
+  }),
+  ENTITY: Object.freeze({
+    CREATE: "entity_create",
+    READ: "entity_read",
+    UPDATE: "entity_update",
+    DELETE: "entity_delete",
+  }),
+  ENTITY_INSTANCE: Object.freeze({
+    CREATE: "entity_instance_create",
+    READ: "entity_instance_read",
+    UPDATE: "entity_instance_update",
+    DELETE: "entity_instance_delete",
+  }),
+  RESERVATION: Object.freeze({
+    CREATE: "reservation_create",
+    READ: "reservation_read",
+    UPDATE: "reservation_update",
+    DELETE: "reservation_delete",
+  }),
+});
+


### PR DESCRIPTION
# feat(utils): add centralized roles and permissions utility

## Description
This PR introduces a new `utils/roles.js` file that centralizes the definition of system roles, permissions, and role-to-permission mappings.  
The goal is to avoid hardcoding IDs or strings throughout the codebase, improve readability, and simplify future maintenance.

## Related Jira Ticket
[boa-44](https://isaacquintero4k-1755629613265.atlassian.net/browse/BOA-44?atlOrigin=eyJpIjoiOTg5YjhkMTMwYWY3NDk4Nzk4YzQ5M2YyZDJjM2NlZTMiLCJwIjoiaiJ9)

## Screenshots (if UI changes)
N/A

## Additional Notes
- Roles are now represented by numeric IDs (`SUPER_ADMIN`, `ADMIN`, `STAFF`) matching database values.  
- Permissions are grouped by domain (Company, User, Customer, Entity, Entity Instance, Reservation).  
- `RolePermissions` maps each role to its allowed permissions for easier use in services or middleware.  
