### PR TITLE
fix: adding middleware to the main routers

### DIFF
--- a/backend/src/routes/adminRouter.js
+++ b/backend/src/routes/adminRouter.js
@@ -2,11 +2,14 @@ import { Router } from "express";
 import { validate } from "../middlewares/ValidationMiddleware.js";
 import AdminService from "../services/adminService.js";
 import createUser from "../schemas/admin/createSchema.js";
+import { Permissions } from "../utils/roles.js";
+import { authorize } from "../middlewares/AuthorizationMiddleware.js";
+
 
 
 
 const AdminRouter = Router();
 
-AdminRouter.post("/create",validate(createUser),AdminService.create);
+AdminRouter.post("/create", authorize(Permissions.USER.CREATE_ADMIN), validate(createUser), AdminService.create);
 
 export default AdminRouter;

--- a/backend/src/routes/workerRouter.js
+++ b/backend/src/routes/workerRouter.js
@@ -2,10 +2,13 @@ import { Router } from "express";
 import { validate } from "../middlewares/ValidationMiddleware.js";
 import WorkerService from "../services/workerService.js";
 import createUser from "../schemas/admin/createSchema.js";
+import { Permissions } from "../utils/roles.js"; 
+import { authorize } from "../middlewares/AuthorizationMiddleware.js";
 
 
 const WorkerRouter = Router()
 
-WorkerRouter.post("/create", validate(createUser), WorkerService.create)
+WorkerRouter.post("/create", authorize(Permissions.USER.CREATE_STAFF), validate(createUser), WorkerService.create
+);
 
 export default WorkerRouter


### PR DESCRIPTION
# feat(admin): add authorization middleware to admin creation endpoint

## Description
This PR adds the `authorize` middleware to the `POST /create` route in `AdminRouter`.  
Now, only users with the `Permissions.USER.CREATE_ADMIN` permission will be able to create new admin users.  
This strengthens access control and aligns the route with our role-based authorization strategy.

## Related Jira Ticket
[boa-49](https://isaacquintero4k-1755629613265.atlassian.net/browse/BOA-49?atlOrigin=eyJpIjoiYWQ0N2JkZjNjNGI1NDM4ODk5ZGViMzMwZGU3NzNlZTkiLCJwIjoiaiJ9)

## Screenshots (if UI changes)
N/A

## Additional Notes
- Integrated `authorize` with `Permissions.USER.CREATE_ADMIN`.
- Integrated `authorize` with `Permissions.USER.CREATE_WORKER`.
- Ensures admin creation is restricted to roles with the correct permission.
- Improves security and consistency across the authorization layer.