### PR TITLE
fix: add authorize for company

### DIFF
--- a/backend/src/routes/companyRouter.js
+++ b/backend/src/routes/companyRouter.js
@@ -2,10 +2,12 @@ import { Router } from "express";
 import { validate } from "../middlewares/ValidationMiddleware.js";
 import companyService from "../services/companyService.js";
 import createCompany from "../schemas/company/createCompanySchema.js";
+import { Permissions } from "../utils/roles.js";
+import { authorize } from "../middlewares/AuthorizationMiddleware.js";
 
 
 const companyRouter = Router();
 
-companyRouter.post("/create",validate(createCompany),companyService.createCompany);
+companyRouter.post("/create",authorize(Permissions.COMPANY.CREATE ),validate(createCompany),companyService.createCompany);
 
 export default companyRouter;


### PR DESCRIPTION
# Add authorization middleware to create company endpoint
  
## Description  
This PR adds the `authorize` middleware to the `create company` endpoint, ensuring that only users with the proper `CREATE_COMPANY` permission can access this functionality.  

## Related Jira Ticket  
_Link the Jira issue code (e.g. `BOA-XXX`)._  

## Screenshots (if UI changes)  
N/A  

## Additional Notes  
- Integrated `Permissions.CREATE_COMPANY` with the `authorize` middleware.  
- This change improves security by restricting unauthorized access.  
