### PR TITLE
feat: create edit in table of reservations

### DIFF
--- a/frontend/src/js/components/table.js
+++ b/frontend/src/js/components/table.js
@@ -12,7 +12,7 @@ export default function Table({ columns, data }) {
       ${data
         .map(
           (row) => `
-        <tr>
+        <tr data-id="${row.id}">
           ${columns
             .map((col) => {
               if (col.field === "actions") {
@@ -24,26 +24,21 @@ export default function Table({ columns, data }) {
                     <button class="btn btn-circle btn-text btn-sm" aria-label="Delete">
                       <span class="icon-[tabler--trash] size-5"></span>
                     </button>
-                    <button class="btn btn-circle btn-text btn-sm" aria-label="More">
-                      <span class="icon-[tabler--dots-vertical] size-5"></span>
-                    </button>
                   </td>
                 `;
               }
 
-              // 👇 corregido: ahora chequea reservation_status
               if (col.field === "reservation_status") {
                 let badgeClass = "badge-soft badge-primary";
-                if (row[col.field] === "Rejected")
-                  badgeClass = "badge-soft badge-error";
-                if (row[col.field] === "Pending")
-                  badgeClass = "badge-soft badge-warning";
-                if (row[col.field] === "Confirmed")
-                  badgeClass = "badge-soft badge-success";
+                if (row[col.field] === "Rejected") badgeClass = "badge-soft badge-error";
+                if (row[col.field] === "Pending") badgeClass = "badge-soft badge-warning";
+                if (row[col.field] === "Confirmed") badgeClass = "badge-soft badge-success";
 
-                return `<td><span class="badge ${badgeClass} text-xs">${
-                  row[col.field]
-                }</span></td>`;
+                return `
+                  <td class="status-cell">
+                    <span class="badge ${badgeClass} text-xs">${row[col.field]}</span>
+                  </td>
+                `;
               }
 
               return `<td>${row[col.field] || ""}</td>`;
@@ -56,6 +51,7 @@ export default function Table({ columns, data }) {
     </tbody>
   `;
 
+  // Retornamos la tabla
   return `
     <div class="w-full overflow-x-auto">
       <table class="table">
@@ -65,3 +61,46 @@ export default function Table({ columns, data }) {
     </div>
   `;
 }
+
+// 👇 Script para manejar editar y actualizar estado
+document.addEventListener("click", (e) => {
+  // Cuando se da clic en el botón Editar
+  if (e.target.closest("[aria-label='Edit']")) {
+    const rowEl = e.target.closest("tr");
+    const statusCell = rowEl.querySelector(".status-cell");
+    const currentStatus = statusCell.textContent.trim();
+    const id = rowEl.dataset.id;
+
+    // Reemplazamos badge por un select
+    statusCell.innerHTML = `
+      <select class="status-select" data-id="${id}">
+        <option value="Pending" ${currentStatus === "Pending" ? "selected" : ""}>Pending</option>
+        <option value="Confirmed" ${currentStatus === "Confirmed" ? "selected" : ""}>Confirmed</option>
+        <option value="Rejected" ${currentStatus === "Rejected" ? "selected" : ""}>Rejected</option>
+      </select>
+    `;
+  }
+});
+
+// Capturamos cambio en el select
+document.addEventListener("change", (e) => {
+  if (e.target.classList.contains("status-select")) {
+    const newStatus = e.target.value;
+    const id = e.target.dataset.id;
+
+    console.log("Actualizar reserva", id, "a estado:", newStatus);
+
+    // Aquí llamas a tu servicio o API
+    // updateReservationStatus(id, newStatus);
+
+    // Opcional: volver a mostrar badge
+    let badgeClass = "badge-soft badge-primary";
+    if (newStatus === "Rejected") badgeClass = "badge-soft badge-error";
+    if (newStatus === "Pending") badgeClass = "badge-soft badge-warning";
+    if (newStatus === "Confirmed") badgeClass = "badge-soft badge-success";
+
+    e.target.parentElement.innerHTML = `
+      <span class="badge ${badgeClass} text-xs">${newStatus}</span>
+    `;
+  }
+});


### PR DESCRIPTION
# Create edit table of reservations

## Description
This PR adds the ability to edit the reservation status directly from the table.  
- Added an **Edit** button to replace the badge with a select dropdown.  
- Implemented status update handling (`Pending`, `Confirmed`, `Rejected`).  
- Restores the badge view after selecting a new status.  
- Prepared for integration with the API service (`updateReservationStatus`).  

## Related Jira Ticket
[boa-66](https://isaacquintero4k-1755629613265.atlassian.net/browse/BOA-66?atlOrigin=eyJpIjoiZTExODVlZTcyZjIzNDUxNmI2YjIxZTU3ZTFiN2IxNjQiLCJwIjoiaiJ9)

## Screenshots (if UI changes)

### Before
_Badges were static and could not be edited._

### After
_A badge can be edited via select and updated dynamically._
![screenshot-placeholder](https://via.placeholder.com/600x300?text=Edit+Status+Demo)

## Additional Notes
- Integration with the backend service should be added where `updateReservationStatus(id, newStatus)` is indicated.  
- Ensures a smoother workflow by avoiding page reloads when updating statuses.
